### PR TITLE
Expand domiflist to optionally include vlan information (for use in openvswitch environments).

### DIFF
--- a/virpy/command/domiflist.py
+++ b/virpy/command/domiflist.py
@@ -36,7 +36,7 @@ class DomiflistCommand(virpy.classes.Command):
             if tagObj is None:
                 return None
 
-            return tagObj.attrib[key]
+            return tagObj.attrib.get(key)
 
         data = []
 

--- a/virpy/command/domiflist.py
+++ b/virpy/command/domiflist.py
@@ -49,6 +49,24 @@ class DomiflistCommand(virpy.classes.Command):
                 'mac': attrval(iface, 'mac', 'address'),
             }
 
+            if rec['source'] is None:
+                rec['source_bridge'] = attrval(iface, 'source', 'bridge')
+
+            rec['vlan_trunk'] = attrval(iface, 'vlan', 'trunk')
+            if rec['vlan_trunk'] is None:
+                rec['vlan_trunk'] = 'no'
+            else:
+                rec['vlans'] = []
+                for vlan in iface.iter('vlan'):
+                    for tag in vlan.iter('tag'):
+                        vlan_rec = {}
+                        vlan_rec['id'] = tag.attrib['id']
+                        if tag.attrib.get('nativeMode') is not None:
+                            vlan_rec['nativeMode'] = tag.attrib.get('nativeMode')
+                        rec['vlans'].append(vlan_rec)
+            for virtualport in iface.iter('virtualport'):
+                rec['virtualport'] = attrval(virtualport, 'parameters', 'interfaceid')
+
             data.append(rec)
 
         return data


### PR DESCRIPTION
When libvirt is used in conjunction with Open vSwitch some additional Xml elements are present in the domain definition.  This change expands the output of domiflist to include an array `vlans` containing each tag, a field `vlan_trunk` which indicates this port is in trunk mode and `virtualport` which is the id of the port in the Open vSwitch database.

Example with vlans, where vlan 6 is an untagged native vlan for the interface and vlan 1 is tagged:
```json
{
  "data": [
    {
      "interface": "vnet0",
      "type": "bridge",
      "source": null,
      "model": "virtio",
      "mac": "52:54:00:xx:xx:xx",
      "source_bridge": "ovsbr",
      "vlan_trunk": "yes",
      "vlans": [
        {
          "id": "6"
        },
        {
          "id": "1",
          "nativeMode": "untagged"
        }
      ],
      "virtualport": "d0bb230b-9be4-41f7-9cf9-906868df0bd4"
    }
  ]
}
```

Example of when Open vSwitch is not used:
```json
{
  "data": [
    {
      "interface": "vnet1",
      "type": "network",
      "source": "default",
      "model": "e1000e",
      "mac": "52:54:00:a8:df:7b",
      "vlan_trunk": "no"
    }
  ]
}
```

Sorry if the code is a bit rough, I'm not a Python developer.